### PR TITLE
IO-298: Update cloudbuild.yaml and Dockerfile for "kritis-signer"

### DIFF
--- a/deploy/kritis-signer/Dockerfile
+++ b/deploy/kritis-signer/Dockerfile
@@ -8,8 +8,8 @@ COPY ./cmd ./cmd
 RUN CGO_ENABLED=0 GOOS=linux go build -o /out/kritis-signer ./cmd/kritis/signer
 
 # Stage 2 - Build the final image.
-# Based on busybox because of the need of `sh`, `cat`, and `openssl` with root certificates.
-FROM debian:12-slim@sha256:3d5df92588469a4c503adbead0e4129ef3f88e223954011c2169073897547cac
+# Based on debian because of the need of `sh`, `cat`, and `openssl` with root certificates.
+FROM gcr.io/google-appengine/debian10:latest
 WORKDIR /
 COPY --from=build-stage /out/kritis-signer /kritis-signer
 ENTRYPOINT ["/kritis-signer"]

--- a/deploy/kritis-signer/Dockerfile
+++ b/deploy/kritis-signer/Dockerfile
@@ -8,8 +8,8 @@ COPY ./cmd ./cmd
 RUN CGO_ENABLED=0 GOOS=linux go build -o /out/kritis-signer ./cmd/kritis/signer
 
 # Stage 2 - Build the final image.
-# Based on busybox because of the need of `sh` and `cat`
-FROM busybox:1.36-uclibc
+# Based on busybox because of the need of `sh`, `cat`, and `openssl` with root certificates.
+FROM debian:12-slim@sha256:3d5df92588469a4c503adbead0e4129ef3f88e223954011c2169073897547cac
 WORKDIR /
 COPY --from=build-stage /out/kritis-signer /kritis-signer
 ENTRYPOINT ["/kritis-signer"]

--- a/deploy/kritis-signer/Dockerfile
+++ b/deploy/kritis-signer/Dockerfile
@@ -8,8 +8,8 @@ COPY ./cmd ./cmd
 RUN CGO_ENABLED=0 GOOS=linux go build -o /out/kritis-signer ./cmd/kritis/signer
 
 # Stage 2 - Build the final image.
-# Based on debian because of the need of `sh`, `cat`, and `openssl` with root certificates.
-FROM gcr.io/google-appengine/debian10:latest
+# Based on alpine because of the need of `sh`, `cat`, and `openssl` with root certificates.
+FROM alpine:3.19.1
 WORKDIR /
 COPY --from=build-stage /out/kritis-signer /kritis-signer
 ENTRYPOINT ["/kritis-signer"]

--- a/deploy/kritis-signer/Dockerfile
+++ b/deploy/kritis-signer/Dockerfile
@@ -1,5 +1,5 @@
 # Build the application from source
-FROM golang:1.19 AS build-stage
+FROM golang:1.21 AS build-stage
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/deploy/kritis-signer/Dockerfile
+++ b/deploy/kritis-signer/Dockerfile
@@ -1,22 +1,15 @@
-# Copyright 2020 Google, Inc. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Build the application from source
+FROM golang:1.19 AS build-stage
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY ./pkg ./pkg
+COPY ./cmd ./cmd
+RUN CGO_ENABLED=0 GOOS=linux go build -o /out/kritis-signer ./cmd/kritis/signer
 
-# Builds the static Go image for Admission validation controller.
-
-FROM gcr.io/google-appengine/debian10:latest
-COPY out/signer /kritis/signer
-ENV HOME /root
-ENV USER /root
-ENV PATH /usr/local/bin:/kritis
-ENTRYPOINT ["/kritis/signer"]
+# Copy the application binary into a thin base image
+FROM gcr.io/distroless/base AS run-stage
+WORKDIR /
+COPY --from=build-stage /out/kritis-signer /kritis-signer
+USER nonroot:nonroot
+ENTRYPOINT ["/kritis-signer"]

--- a/deploy/kritis-signer/Dockerfile
+++ b/deploy/kritis-signer/Dockerfile
@@ -1,4 +1,4 @@
-# Build the application from source
+# Stage 1 - Build the application from source
 FROM golang:1.21 AS build-stage
 WORKDIR /app
 COPY go.mod go.sum ./
@@ -7,9 +7,9 @@ COPY ./pkg ./pkg
 COPY ./cmd ./cmd
 RUN CGO_ENABLED=0 GOOS=linux go build -o /out/kritis-signer ./cmd/kritis/signer
 
-# Copy the application binary into a thin base image
-FROM gcr.io/distroless/base AS run-stage
+# Stage 2 - Build the final image.
+# Based on busybox because of the need of `sh` and `cat`
+FROM busybox:1.36-uclibc
 WORKDIR /
 COPY --from=build-stage /out/kritis-signer /kritis-signer
-USER nonroot:nonroot
 ENTRYPOINT ["/kritis-signer"]

--- a/deploy/kritis-signer/cloudbuild.yaml
+++ b/deploy/kritis-signer/cloudbuild.yaml
@@ -1,19 +1,29 @@
+substitutions:
+  _GAR_REPOSITORY: "europe-docker.pkg.dev/${PROJECT_ID}/billhop-tools-eu"
+  _IMAGE_NAME: "kritis-signer"
+
+options:
+  automapSubstitutions: true
+
 steps:
-- id: "build signer binary"
-  name: 'gcr.io/cloud-builders/go:debian'
-  args: ['build', '-o', 'out/signer', './cmd/kritis/signer']
-  env: ['PROJECT_ROOT=github.com/grafeas/kritis']
-- id: 'build signer image'
-  name: 'gcr.io/cloud-builders/docker'
-  args:
-  - 'build'
-  - '-f'
-  - 'deploy/kritis-signer/Dockerfile'
-  - '-t'
-  - 'gcr.io/$PROJECT_ID/kritis-signer:latest'
-  - '.'
-- id: 'publish'
-  name: 'gcr.io/cloud-builders/docker'
-  args:
-  - 'push'
-  - 'gcr.io/$PROJECT_ID/kritis-signer:latest'
+  - name: "gcr.io/cloud-builders/docker"
+    id: "build-image"
+    script: |
+      #!/bin/sh -e
+      docker build \
+        -f ./deploy/kritis-signer/Dockerfile \
+        -t "${_GAR_REPOSITORY}/${_IMAGE_NAME}:${COMMIT_SHA}" \
+        .
+
+  - name: "gcr.io/cloud-builders/docker"
+    id: "publish-image"
+    script: |
+      #!/bin/sh -e
+      docker push "${_GAR_REPOSITORY}/${_IMAGE_NAME}:${COMMIT_SHA}"
+
+      if [ "$BRANCH_NAME" = "master" ]; then
+        docker tag \
+          "${_GAR_REPOSITORY}/${_IMAGE_NAME}:${COMMIT_SHA}" \
+          "${_GAR_REPOSITORY}/${_IMAGE_NAME}:latest"
+        docker push "${_GAR_REPOSITORY}/${_IMAGE_NAME}:latest"
+      fi

--- a/deploy/kritis-signer/cloudbuild.yaml
+++ b/deploy/kritis-signer/cloudbuild.yaml
@@ -21,7 +21,7 @@ steps:
       #!/bin/sh -e
       docker push "${_GAR_REPOSITORY}/${_IMAGE_NAME}:${COMMIT_SHA}"
 
-      if [ "$BRANCH_NAME" = "master" ]; then
+      if [ "$BRANCH_NAME" = "billhop-custom" ]; then
         docker tag \
           "${_GAR_REPOSITORY}/${_IMAGE_NAME}:${COMMIT_SHA}" \
           "${_GAR_REPOSITORY}/${_IMAGE_NAME}:latest"


### PR DESCRIPTION
- Build "kritis-signer" image in a multistage build, using alpine as a runtime base image. That reduces the image size and amount of vulnerabilities, but still keeps it possible to use `sh`, `cat` and verify TLS/SSL certificates.
- Use Billhop image tagging convention